### PR TITLE
Define ssh configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ setting UI automatically.
 You will need to rewrite the file manualy by runing the admin command:
 ![image](https://user-images.githubusercontent.com/6057298/167601533-4f1c3100-db98-4a86-95ea-dd0b7970f664.png)
 
-see: https://github.com/gogs/gogs/issues/4751https://github.com/gogs/gogs/issues/4751
+see: https://github.com/gogs/gogs/issues/4751
 
 ### Test the `Gogs` Instance
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,19 @@ You will see output confirming the restart:
 gogs-server is being restarted
 ```
 
+Make sure to have `START_SSH_SERVER` to false in your `app.ini` file:
+
+```sh
+START_SSH_SERVER = false
+```
+
+If defined to `true` you might not be able to add ssh keys via the Gogs
+setting UI automatically.
+You will need to rewrite the file manualy by runing the admin command:
+![image](https://user-images.githubusercontent.com/6057298/167601533-4f1c3100-db98-4a86-95ea-dd0b7970f664.png)
+
+see: https://github.com/gogs/gogs/issues/4751https://github.com/gogs/gogs/issues/4751
+
 ### Test the `Gogs` Instance
 
 https://gogs-server.fly.dev/nelsonic

--- a/app.ini
+++ b/app.ini
@@ -21,7 +21,7 @@ HTTP_PORT        = 3000
 EXTERNAL_URL     = https://gogs-server.fly.dev/
 DISABLE_SSH      = false
 SSH_PORT         = 10022
-START_SSH_SERVER = true
+START_SSH_SERVER = false
 OFFLINE_MODE     = false
 
 [mailer]


### PR DESCRIPTION
Set START_SSH_SERVER = false in app.ini file.
This allow users to add/remove ssh keys automatically in the
authorized_keys file

related to: #2